### PR TITLE
Update navbar_include.md

### DIFF
--- a/wiki/_wethreepedia/faq/faq.md
+++ b/wiki/_wethreepedia/faq/faq.md
@@ -727,7 +727,7 @@ You can read more about Threefold cloud pricing [here](https://library.threefold
 
 ### **How can I create a profile manager on play.grid.tf?**
 
-Read [this documentation](https://library.threefold.me/info/manual/#/manual__weblets_profile_manager).
+Read [this documentation](https://manual.grid.tf/weblets/weblets_profile_manager.html).
 
 
 ***

--- a/wiki/navbar_include.md
+++ b/wiki/navbar_include.md
@@ -7,7 +7,7 @@
   - [Grid Capacity Explorer](https://dashboard.grid.tf/explorer/statistics/)
   - [Playground: Mainnet](https://play.grid.tf/)
   - [Playground: Testnet](https://play.test.grid.tf/)
-  - [Manual](https://library.threefold.me/info/manual/#/manual__manual3_home_new)
+  - [Manual](https://manual.grid.tf/)
 
   <!-- - [TF Token Stats](https://tokenstats.threefoldtoken.com/) -->
   <!-- - [TFGrid Demo](https://demo.testnet.grid.tf/)


### PR DESCRIPTION
The manual link under the TF Grid Tools in the library has been changed to https://manual.grid.tf/